### PR TITLE
polyfilled Object.assign for IE

### DIFF
--- a/carbon-route.html
+++ b/carbon-route.html
@@ -171,6 +171,23 @@ the `carbon-route` will update `route.path`. This in-turn will update the
       this.linkPaths('tail.__queryParams', 'route.__queryParams');
     },
 
+    // IE Object.assign polyfill
+    __assign: function(target) {
+      target = Object(target);
+
+      for (var i = 1; i < arguments.length; i++) {
+        var source = arguments[i];
+
+        if (source !== undefined || source !== null) {
+          for (var key in source) {
+            target[key] = source[key];
+          }
+        }
+      }
+
+      return target;
+    },
+
     // Deal with the query params object being assigned to wholesale
     __routeQueryParamsChanged: function(queryParams) {
       if (queryParams && this.tail) {
@@ -181,7 +198,16 @@ the `carbon-route` will update `route.path`. This in-turn will update the
         }
 
         this._skipMatch = true;
-        this.set('queryParams', Object.assign({}, queryParams));
+
+        var qp;
+
+        if (Object.assign) {
+          qp = Object.assign({}, queryParams);
+        } else {
+          qp = this.__assign({}, queryParams);
+        }
+
+        this.set('queryParams', qp);
         this._skipMatch = false;
       }
     },

--- a/carbon-route.html
+++ b/carbon-route.html
@@ -173,7 +173,7 @@ the `carbon-route` will update `route.path`. This in-turn will update the
 
     // IE Object.assign polyfill
     __assign: function(target, source) {
-      if (source !== undefined || source !== null) {
+      if (source != null) {
         for (var key in source) {
           target[key] = source[key];
         }

--- a/carbon-route.html
+++ b/carbon-route.html
@@ -172,16 +172,10 @@ the `carbon-route` will update `route.path`. This in-turn will update the
     },
 
     // IE Object.assign polyfill
-    __assign: function(target) {
-      target = Object(target);
-
-      for (var i = 1; i < arguments.length; i++) {
-        var source = arguments[i];
-
-        if (source !== undefined || source !== null) {
-          for (var key in source) {
-            target[key] = source[key];
-          }
+    __assign: function(target, source) {
+      if (source !== undefined || source !== null) {
+        for (var key in source) {
+          target[key] = source[key];
         }
       }
 

--- a/test/carbon-location.html
+++ b/test/carbon-location.html
@@ -158,7 +158,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('changing the urlSpace pattern and testing paths', function() {
           setLocationClick('/test');
 
-          carbonLocation.urlSpaceRegex = '/foo'
+          carbonLocation.urlSpaceRegex = '/foo';
 
           expect(carbonLocation.route.path).to.be.equal('/test');
 
@@ -171,7 +171,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           setLocationClick('/bar');
           expect(carbonLocation.route.path).to.be.equal('/foo/bar');
 
-          carbonLocation.urlSpaceRegex = '/foo/[0-9]+'
+          carbonLocation.urlSpaceRegex = '/foo/[0-9]+';
 
           setLocationClick('/foo/123');
           expect(carbonLocation.route.path).to.be.equal('/foo/123');


### PR DESCRIPTION
fixes #60. window.location.origin in [iron-location](https://github.com/PolymerElements/iron-location/blob/db8f5068ff8a91fa97edc80b41a9a9338ee84a1f/iron-location.html#L284) needs to be polyfilled for IE so that these tests will pass. [This PR](https://github.com/PolymerElements/iron-location/pull/24) should fix this issue.