### PR TITLE
Add @export annotations to observer methods.

### DIFF
--- a/carbon-route.html
+++ b/carbon-route.html
@@ -182,7 +182,10 @@ the `carbon-route` will update `route.path`. This in-turn will update the
       return target;
     },
 
-    // Deal with the query params object being assigned to wholesale
+    /**
+     * Deal with the query params object being assigned to wholesale.
+     * @export
+     */
     __routeQueryParamsChanged: function(queryParams) {
       if (queryParams && this.tail) {
         this.set('tail.__queryParams', queryParams);
@@ -206,12 +209,18 @@ the `carbon-route` will update `route.path`. This in-turn will update the
       }
     },
 
+    /**
+     * @export
+     */
     __tailQueryParamsChanged: function(queryParams) {
       if (queryParams && this.route) {
         this.set('route.__queryParams', queryParams);
       }
     },
 
+    /**
+     * @export
+     */
     __queryParamsChanged: function(changes) {
       if (!this.active || this._skipMatch) {
         return;
@@ -227,6 +236,9 @@ the `carbon-route` will update `route.path`. This in-turn will update the
       //this.data = {};
     },
 
+    /**
+     * @export
+     */
     __tryToMatch: function(path, pattern) {
       if (this._skipMatch || !pattern) {
         return;
@@ -287,6 +299,9 @@ the `carbon-route` will update `route.path`. This in-turn will update the
       this._skipMatch = false;
     },
 
+    /**
+     * @export
+     */
     __tailPathChanged: function(path) {
       if (!this.active || this._skipMatch) {
         return;
@@ -301,6 +316,9 @@ the `carbon-route` will update `route.path`. This in-turn will update the
       this.set('route.path', newPath);
     },
 
+    /**
+     * @export
+     */
     __updatePathOnDataChange: function() {
       if (!this.route || this._skipMatch || !this.active) {
         return;


### PR DESCRIPTION
The @export annotations were not really designed for private methods, but this is a stop-gap patch for #91 which seems to be tickling some bug in either this code or the closure compiler. This fixes a problem where the observer methods get minimized but the definitions inside the `observers` property do not get minimized causing js errors when it cannot find the observer methods.