### PR TITLE
Add robust redirection support.

### DIFF
--- a/carbon-location.html
+++ b/carbon-location.html
@@ -148,8 +148,8 @@ Example:
         }
       },
 
-      __computeRoutePath: function(path, hash, useHashAsPath) {
-        return useHashAsPath ? hash : path;
+      __computeRoutePath: function() {
+        return this.useHashAsPath ? this.__hash : this.__path;
       },
 
       __onPathChanged: function(event) {

--- a/carbon-route-converter.html
+++ b/carbon-route-converter.html
@@ -126,11 +126,16 @@ turn is consumed by the `carbon-route`.
      * @param  {Object} queryParams A set of key/value pairs that are
      * universally accessible to branches of the route tree.
      */
-    _locationChanged: function(path, queryParams) {
+    _locationChanged: function() {
+      if (this.route &&
+          this.route.path === this.path &&
+          this.queryParams === this.route.__queryParams) {
+        return;
+      }
       this.route = {
         prefix: '',
-        path: path,
-        __queryParams: queryParams
+        path: this.path,
+        __queryParams: this.queryParams
       };
     },
 
@@ -141,12 +146,12 @@ turn is consumed by the `carbon-route`.
      * path.
      * @param  {!string} path The serialized path through the route tree.
      */
-    _routeChanged: function(prefix, path) {
+    _routeChanged: function() {
       if (!this.route) {
         return;
       }
 
-      this.path = prefix + path;
+      this.path = this.route.prefix + this.route.path;
     },
 
     /**

--- a/carbon-route.html
+++ b/carbon-route.html
@@ -144,7 +144,7 @@ the `carbon-route` will update `route.path`. This in-turn will update the
         readOnly: true
       },
 
-      _skipMatch: {
+      _queryParamsUpdating: {
         type: Boolean,
         value: false
       },
@@ -173,6 +173,9 @@ the `carbon-route` will update `route.path`. This in-turn will update the
 
     // IE Object.assign polyfill
     __assign: function(target, source) {
+      if (Object.assign) {
+        return Object.assign(target, source);
+      }
       if (source != null) {
         for (var key in source) {
           target[key] = source[key];
@@ -190,22 +193,13 @@ the `carbon-route` will update `route.path`. This in-turn will update the
       if (queryParams && this.tail) {
         this.set('tail.__queryParams', queryParams);
 
-        if (!this.active || this._skipMatch) {
+        if (!this.active || this._queryParamsUpdating) {
           return;
         }
 
-        this._skipMatch = true;
-
-        var qp;
-
-        if (Object.assign) {
-          qp = Object.assign({}, queryParams);
-        } else {
-          qp = this.__assign({}, queryParams);
-        }
-
-        this.set('queryParams', qp);
-        this._skipMatch = false;
+        this._queryParamsUpdating = true;
+        this.set('queryParams', this.__assign({}, queryParams));
+        this._queryParamsUpdating = false;
       }
     },
 
@@ -222,7 +216,7 @@ the `carbon-route` will update `route.path`. This in-turn will update the
      * @export
      */
     __queryParamsChanged: function(changes) {
-      if (!this.active || this._skipMatch) {
+      if (!this.active || this._queryParamsUpdating) {
         return;
       }
 
@@ -239,8 +233,13 @@ the `carbon-route` will update `route.path`. This in-turn will update the
     /**
      * @export
      */
-    __tryToMatch: function(path, pattern) {
-      if (this._skipMatch || !pattern) {
+    __tryToMatch: function() {
+      if (!this.route) {
+        return;
+      }
+      var path = this.route.path;
+      var pattern = this.pattern;
+      if (!pattern) {
         return;
       }
 
@@ -277,41 +276,54 @@ the `carbon-route` will update `route.path`. This in-turn will update the
         }
       }
 
-      matched = matched.join('/');
+      this._matched = matched.join('/');
+
+      // Properties that must be updated atomically.
+      var propertyUpdates = {};
+
+      //this.active
+      propertyUpdates.active = true;
+
+      // this.tail
+      var tailPrefix = this.route.prefix + this._matched;
       var tailPath = remainingPieces.join('/');
       if (remainingPieces.length > 0) {
         tailPath = '/' + tailPath;
       }
-
-      this._skipMatch = true;
-      this._matched = matched;
-      this.data = namedMatches;
-      var tailPrefix = this.route.prefix + matched;
-
-      if (!this.tail || this.tail.prefix !== tailPrefix || this.tail.path !== tailPath) {
-        this.tail = {
+      if (!this.tail ||
+          this.tail.prefix !== tailPrefix ||
+          this.tail.path !== tailPath) {
+        propertyUpdates.tail = {
           prefix: tailPrefix,
           path: tailPath,
           __queryParams: this.route.__queryParams
         };
       }
-      this._setActive(true);
-      this._skipMatch = false;
+
+      // this.data
+      propertyUpdates.data = namedMatches;
+      this._dataInUrl = {};
+      for (var key in namedMatches) {
+        this._dataInUrl[key] = namedMatches[key];
+      }
+
+      this.__setMulti(propertyUpdates);
     },
 
     /**
      * @export
      */
-    __tailPathChanged: function(path) {
-      if (!this.active || this._skipMatch) {
+    __tailPathChanged: function() {
+      if (!this.active) {
         return;
       }
+      var tailPath = this.tail.path;
       var newPath = this._matched;
-      if (path) {
-        if (path.charAt(0) !== '/') {
-          path = '/' + path;
+      if (tailPath) {
+        if (tailPath.charAt(0) !== '/') {
+          tailPath = '/' + tailPath;
         }
-        newPath += path;
+        newPath += tailPath;
       }
       this.set('route.path', newPath);
     },
@@ -320,17 +332,19 @@ the `carbon-route` will update `route.path`. This in-turn will update the
      * @export
      */
     __updatePathOnDataChange: function() {
-      if (!this.route || this._skipMatch || !this.active) {
+      if (!this.route || !this.active) {
         return;
       }
-      this._skipMatch = true;
-      this.tail = {path: null, prefix: null, queryParams: null};
-      this.set('route.path', this.__getLink({}));
-      this._skipMatch = false;
+      var newPath = this.__getLink({});
+      var oldPath = this.__getLink(this._dataInUrl);
+      if (newPath === oldPath) {
+        return;
+      }
+      this.set('route.path', newPath);
     },
 
     __getLink: function(overrideValues) {
-      var values = {tail: this.tail};
+      var values = {tail: null};
       for (var key in this.data) {
         values[key] = this.data[key];
       }
@@ -345,9 +359,35 @@ the `carbon-route` will update `route.path`. This in-turn will update the
         return value;
       }, this);
       if (values.tail && values.tail.path) {
-        interp.push(values.tail.path);
+        if (interp.length > 0 && values.tail.path.charAt(0) === '/') {
+          interp.push(values.tail.path.slice(1));
+        } else {
+          interp.push(values.tail.path);
+        }
       }
       return interp.join('/');
+    },
+
+    __setMulti: function(setObj) {
+      // HACK(rictic): skirting around 1.0's lack of a setMulti by poking at
+      //     internal data structures. I would not advise that you copy this
+      //     example.
+      //
+      //     In the future this will be a feature of Polymer itself.
+      //     See: https://github.com/Polymer/polymer/issues/3640
+      //
+      //     Hacking around with private methods like this is juggling footguns,
+      //     and is likely to have unexpected and unsupported rough edges.
+      //
+      //     Be ye so warned.
+      for (var property in setObj) {
+        this._propertySetter(property, setObj[property]);
+      }
+
+      for (var property in setObj) {
+        this._pathEffector(property, this[property]);
+        this._notifyPathUp(property, this[property]);
+      }
     }
   });
 </script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -146,25 +146,30 @@ http://polymer.github.io/PATENTS.txt
 
           videos: {
             type: Array,
-            value: []
+            value: function() {
+              return [];
+            }
           },
 
           data: {
             type: Object,
-            value: {
-              page: '/search/'
+            value: function() {
+              return {
+                page: '/search/'
+              };
             }
           }
         },
 
-        ready: function() {
-          // TODO: Remove this async https://github.com/PolymerElements/carbon-route/issues/44
-          this.async(function() {
-            // If we do not have an initial URL, we redirect to /search
-            if (!this.route.path) {
-              this.set('route.path', '/search/');
-            }
-          },1);
+        observers: [
+          '_onRoutePathChanged(route.path)'
+        ],
+
+        _onRoutePathChanged: function(path) {
+          // If we do not have an initial URL, we redirect to /search
+          if (!path) {
+            this.set('route.path', '/search/');
+          }
         },
 
         _videoDataChanged: function(data) {

--- a/test/app-example-1.html
+++ b/test/app-example-1.html
@@ -15,25 +15,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template>
     <carbon-location route='{{route}}'>
     </carbon-location>
-    <carbon-route route='{{route}}' pattern='/:page' data='{{data}}'>
+    <carbon-route id="page" route='{{route}}' pattern='/:page' data='{{data}}'>
     </carbon-route>
-    <carbon-route route='{{route}}' pattern='/user' tail='{{userRoute}}'>
+    <carbon-route id="user" route='{{route}}' pattern='/user' tail='{{userRoute}}'>
     </carbon-route>
-    <carbon-route route='{{userRoute}}' pattern='/:page' data='{{userData}}' query-params="{{userQueryParams}}">
+    <carbon-route id="tail" route='{{userRoute}}' pattern='/:page' data='{{userData}}' query-params="{{userQueryParams}}">
     </carbon-route>
   </template>
   <script>
     Polymer({
       is: 'app-example-1',
-      properties: {
-        path: {
-
-        },
-        data: {
-
-        },
-        userData: {
-
+      observers: [
+        'pageChanged(data.page)',
+        'userPathChanged(userRoute.path)',
+      ],
+      pageChanged: function(page) {
+        if (page === 'redirectToUser') {
+          this.set('data.page', 'user');
+        }
+      },
+      userPathChanged: function(path) {
+        // Redirect from /user/ and /user to /user/view
+        if (path === '/' || path === '') {
+          this.set('userRoute.path', '/view');
         }
       }
     })

--- a/test/carbon-location.html
+++ b/test/carbon-location.html
@@ -59,106 +59,109 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     suite('<carbon-location>', function () {
-      var carbonLocation;
+      var initialUrl;
 
       setup(function() {
-        carbonLocation = fixture('BasicLocation');
-      });
-
-      test('it automatically exposes the current route', function() {
-        expect(carbonLocation.route).to.be.ok;
-        expect(carbonLocation.route.path).to.be.equal(window.location.pathname);
-      });
-
-      suite('manipulating the route', function() {
-        var originalPath;
-        var originalQueryParams;
-
-        setup(function() {
-          originalPath = carbonLocation.route.path;
-          originalQueryParams = assign({}, carbonLocation.route.__queryParams);
-        });
-
-        teardown(function() {
-          carbonLocation.set('route.prefix', '');
-          carbonLocation.set('route.path', originalPath);
-          carbonLocation.set('route.__queryParams', originalQueryParams);
-        });
-
-        test('it reflects path to location.pathname', function() {
-          carbonLocation.set('route.path', '/foo/bar');
-          expect(window.location.pathname).to.be.equal('/foo/bar');
-        });
-
-        test('it reflects queryParams values to location.search', function() {
-          carbonLocation.set('route.__queryParams.foo', 1);
-          expect(window.location.search).to.match(/foo=1/);
-        });
-
-        test('it reflects completely replaced queryParams', function() {
-          carbonLocation.set('route.__queryParams', { bar: 1 });
-          expect(window.location.search).to.be.equal('?bar=1');
-        });
-
-        test('it reflects the prefix to location.pathname', function() {
-          carbonLocation.set('route.prefix', '/fiz');
-          expect(window.location.pathname).to.be.equal('/fiz' + originalPath);
-        });
-      });
-
-      /**
-       * NOTE: For a more thorough spec describing this behavior, please refer
-       * to the `iron-location` component.
-       */
-      suite('manipulating the history state', function() {
-        var originalLocation;
-
-        setup(function() {
-          originalLocation = window.location.toString();
-        });
-
-        teardown(function() {
-          setLocation(originalLocation);
-        });
-
-        test('it reflects location.pathname to route.path', function() {
-          setLocation('/fiz/buz');
-          expect(carbonLocation.route.path).to.be.equal('/fiz/buz');
-        });
-
-        test('it reflects location.search to route.__queryParams', function() {
-          setLocation('?fiz=buz');
-          expect(carbonLocation.route.__queryParams).to.be.eql({
-            fiz: 'buz'
-          });
-        });
-      });
-    });
-
-    suite('using the hash as the route path', function() {
-      var carbonLocation;
-      var originalLocation;
-
-      setup(function() {
-        originalLocation = window.location.toString();
+        initialUrl = window.location.href;
       });
 
       teardown(function() {
-        setLocation(originalLocation);
+        window.history.replaceState({}, '', initialUrl);
       });
 
-      setup(function() {
-        carbonLocation = fixture('LocationViaHash');
+      suite('in the default configuration', function() {
+        var carbonLocation;
+
+        setup(function() {
+          carbonLocation = fixture('BasicLocation');
+        });
+
+        test('it automatically exposes the current route', function() {
+          expect(carbonLocation.route).to.be.ok;
+          expect(carbonLocation.route.path).to.be.equal(window.location.pathname);
+        });
+
+        suite('manipulating the route', function() {
+          var originalPath;
+          var originalQueryParams;
+
+          setup(function() {
+            originalPath = carbonLocation.route.path;
+            originalQueryParams = assign({}, carbonLocation.route.__queryParams);
+          });
+
+          teardown(function() {
+            carbonLocation.set('route.prefix', '');
+            carbonLocation.set('route.path', originalPath);
+            carbonLocation.set('route.__queryParams', originalQueryParams);
+          });
+
+          test('it reflects path to location.pathname', function() {
+            carbonLocation.set('route.path', '/foo/bar');
+            expect(window.location.pathname).to.be.equal('/foo/bar');
+          });
+
+          test('it reflects queryParams values to location.search', function() {
+            carbonLocation.set('route.__queryParams.foo', 1);
+            expect(window.location.search).to.match(/foo=1/);
+          });
+
+          test('it reflects completely replaced queryParams', function() {
+            carbonLocation.set('route.__queryParams', { bar: 1 });
+            expect(window.location.search).to.be.equal('?bar=1');
+          });
+
+          test('it reflects the prefix to location.pathname', function() {
+            carbonLocation.set('route.prefix', '/fiz');
+            expect(window.location.pathname).to.be.equal('/fiz' + originalPath);
+          });
+        });
+
+        /**
+         * NOTE: For a more thorough spec describing this behavior, please refer
+         * to the `iron-location` component.
+         */
+        suite('manipulating the history state', function() {
+          var originalLocation;
+
+          setup(function() {
+            originalLocation = window.location.toString();
+          });
+
+          teardown(function() {
+            setLocation(originalLocation);
+          });
+
+          test('it reflects location.pathname to route.path', function() {
+            setLocation('/fiz/buz');
+            expect(carbonLocation.route.path).to.be.equal('/fiz/buz');
+          });
+
+          test('it reflects location.search to route.__queryParams', function() {
+            setLocation('?fiz=buz');
+            expect(carbonLocation.route.__queryParams).to.be.eql({
+              fiz: 'buz'
+            });
+          });
+        });
       });
 
-      test('it reflects location.hash to route.path', function() {
-        setLocation('#/fiz/buz');
-        expect(carbonLocation.route.path).to.be.equal('/fiz/buz');
-      });
+      suite('using the hash as the route path', function() {
+        var carbonLocation;
 
-      test('it reflects route.path to location.hash', function() {
-        carbonLocation.set('route.path', '/foo/bar');
-        expect(window.location.hash).to.be.equal('#/foo/bar');
+        setup(function() {
+          carbonLocation = fixture('LocationViaHash');
+        });
+
+        test('it reflects location.hash to route.path', function() {
+          setLocation('#/fiz/buz');
+          expect(carbonLocation.route.path).to.be.equal('/fiz/buz');
+        });
+
+        test('it reflects route.path to location.hash', function() {
+          carbonLocation.set('route.path', '/foo/bar');
+          expect(window.location.hash).to.be.equal('#/foo/bar');
+        });
       });
     });
   </script>

--- a/test/carbon-route.html
+++ b/test/carbon-route.html
@@ -17,6 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../../polymer/polymer.html">
   <link rel="import" href="../carbon-route.html">
+  <link rel="import" href="./redirection.html">
 </head>
 <body>
   <test-fixture id="BasicRoute">
@@ -48,6 +49,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </carbon-route>
     </template>
   </test-fixture>
+
+  <test-fixture id="Redirection">
+    <template>
+      <redirect-carbon-route></redirect-carbon-route>
+    </template>
+  </test-fixture>
+
 <script>
   'use strict';
 
@@ -87,7 +95,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         path: '/user/papyrus/details',
         __queryParams: {}
       }
-
       expect(route.tail.prefix).to.be.equal('/user/papyrus');
       expect(route.tail.path).to.be.equal('/details');
       expect(route.data.username).to.be.equal('papyrus');
@@ -267,6 +274,177 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(routes.bar.queryParams).to.be.eql({ qux: 'zot' });
           expect(routes.baz.queryParams).to.be.eql({ qux: 'quux' });
         });
+      });
+    });
+
+    suite('handles reentrent changes to its properties', function() {
+      var initialUrl;
+      setup(function() {
+        initialUrl = window.location.href;
+      });
+
+      teardown(function() {
+        window.history.replaceState({}, '', initialUrl);
+      });
+
+      test('changing path in response to path changing', function() {
+        var r = fixture('Redirection');
+        r.addEventListener('route-changed', function() {
+          r.set('route.path', '/bar/baz');
+        });
+        r.set('route.path', '/foo');
+        expect(window.location.pathname).to.be.equal('/bar/baz');
+        expect(r.data).to.be.deep.equal({page: 'bar'});
+        expect(r.route.path).to.be.equal('/bar/baz');
+        expect(r.tail.path).to.be.equal('/baz');
+      });
+
+      test('changing data wholesale in response to path changing', function() {
+        var r = fixture('Redirection');
+        r.set('data.page', 'bar');
+        r.addEventListener('route-changed', function(e) {
+          if (e.detail.path === 'route.path' && r.route.path === '/foo/baz') {
+            r.data = {page: 'bar'};
+          }
+        });
+        r.set('route.path', '/foo/baz');
+        expect(window.location.pathname).to.be.equal('/bar');
+        expect(r.data).to.be.deep.equal({page: 'bar'});
+        expect(r.route.path).to.be.equal('/bar');
+        expect(r.tail.path).to.be.equal('');
+      });
+
+      test('changing a data piece in response to path changing', function() {
+        var r = fixture('Redirection');
+        r.set('data.page', 'bar');
+        r.addEventListener('route-changed', function(e) {
+          r.set('data.page', 'bar');
+        });
+        r.set('route.path', '/foo/baz');
+        expect(window.location.pathname).to.be.equal('/bar');
+        expect(r.data).to.be.deep.equal({page: 'bar'});
+        expect(r.route.path).to.be.equal('/bar');
+        expect(r.tail.path).to.be.equal('');
+      });
+
+      test('changing the tail in response to path changing', function() {
+        var r = fixture('Redirection');
+        r.addEventListener('route-changed', function() {
+          r.set('tail.path', '/bar');
+        });
+        r.set('route.path', '/foo');
+        expect(window.location.pathname).to.be.equal('/foo/bar');
+        expect(r.data).to.be.deep.equal({page: 'foo'});
+        expect(r.route.path).to.be.equal('/foo/bar');
+        expect(r.tail.path).to.be.equal('/bar');
+
+        r.set('route.path', '/foo/baz');
+        expect(window.location.pathname).to.be.equal('/foo/bar');
+        expect(r.data).to.be.deep.equal({page: 'foo'});
+        expect(r.route.path).to.be.equal('/foo/bar');
+        expect(r.tail.path).to.be.equal('/bar');
+      });
+
+      test('changing the path in response to data changing', function() {
+        var r = fixture('Redirection');
+        r.addEventListener('data-changed', function() {
+          r.set('route.path', '/bar');
+        });
+        r.set('data', {page: 'foo'});
+        expect(window.location.pathname).to.be.equal('/bar');
+        expect(r.data).to.be.deep.equal({page: 'bar'});
+        expect(r.route.path).to.be.equal('/bar');
+        expect(r.tail.path).to.be.equal('');
+      });
+
+      test('changing data in response to data changing', function() {
+        var r = fixture('Redirection');
+        r.addEventListener('data-changed', function() {
+          r.set('data.page', 'bar');
+        });
+        r.set('data', {page: 'foo'});
+        expect(window.location.pathname).to.be.equal('/bar');
+        expect(r.data).to.be.deep.equal({page: 'bar'});
+        expect(r.route.path).to.be.equal('/bar');
+        expect(r.tail.path).to.be.equal('');
+      });
+
+      test('changing the data object wholesale in response to data changing', function() {
+        var r = fixture('Redirection');
+        r.addEventListener('data-changed', function() {
+          if (r.data.page == 'foo') {
+            r.set('data', {page: 'bar'});
+          }
+        });
+        r.set('data', {page: 'foo'});
+        expect(window.location.pathname).to.be.equal('/bar');
+        expect(r.data).to.be.deep.equal({page: 'bar'});
+        expect(r.route.path).to.be.equal('/bar');
+        expect(r.tail.path).to.be.equal('');
+      });
+
+      test('changing the tail in response to data changing', function() {
+        var r = fixture('Redirection');
+        r.addEventListener('data-changed', function() {
+          r.set('tail.path', '/bar');
+        });
+        r.set('data', {page: 'foo'});
+        expect(window.location.pathname).to.be.equal('/foo/bar');
+        expect(r.data).to.be.deep.equal({page: 'foo'});
+        expect(r.route.path).to.be.equal('/foo/bar');
+        expect(r.tail.path).to.be.equal('/bar');
+      });
+
+      test('changing the path in response to tail changing', function() {
+        var r = fixture('Redirection');
+        r.set('route.path', '/foo/');
+        r.addEventListener('tail-changed', function() {
+          r.set('route.path', '/baz' + r.tail.path);
+        });
+        r.set('tail.path', '/bar');
+        expect(window.location.pathname).to.be.equal('/baz/bar');
+        expect(r.data).to.be.deep.equal({page: 'baz'});
+        expect(r.route.path).to.be.equal('/baz/bar');
+        expect(r.tail.path).to.be.equal('/bar');
+      });
+
+      test('changing the data in response to tail changing', function() {
+        var r = fixture('Redirection');
+        r.set('route.path', '/foo/');
+        r.addEventListener('tail-changed', function() {
+          r.set('data.page', 'baz');
+        });
+        r.set('tail.path', '/bar');
+        expect(window.location.pathname).to.be.equal('/baz');
+        expect(r.data).to.be.deep.equal({page: 'baz'});
+        expect(r.route.path).to.be.equal('/baz');
+        expect(r.tail.path).to.be.equal('');
+      });
+
+      test('changing the data object wholesale in response to tail changing', function() {
+        var r = fixture('Redirection');
+        r.set('route.path', '/foo/');
+        r.addEventListener('tail-changed', function() {
+          r.set('data', {page: 'baz'});
+        });
+        r.set('tail.path', '/bar');
+        expect(window.location.pathname).to.be.equal('/baz');
+        expect(r.data).to.be.deep.equal({page: 'baz'});
+        expect(r.route.path).to.be.equal('/baz');
+        expect(r.tail.path).to.be.equal('');
+      });
+
+      test('changing the tail in response to tail changing', function() {
+        var r = fixture('Redirection');
+        r.set('route.path', '/foo/');
+        r.addEventListener('tail-changed', function() {
+          r.set('tail.path', '/baz');
+        });
+        r.set('tail.path', '/bar');
+        expect(window.location.pathname).to.be.equal('/foo/baz');
+        expect(r.data).to.be.deep.equal({page: 'foo'});
+        expect(r.route.path).to.be.equal('/foo/baz');
+        expect(r.tail.path).to.be.equal('/baz');
       });
     });
   });

--- a/test/redirection.html
+++ b/test/redirection.html
@@ -1,0 +1,44 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../carbon-location.html">
+<link rel="import" href="../carbon-route.html">
+
+<!--
+ There are three relevant factors to route.path, and when any one of them
+ changes we want to support synchronously updating any of the others.
+-->
+
+<dom-module id='redirect-carbon-route'>
+  <template>
+    <carbon-location route='{{route}}'>
+    </carbon-location>
+    <carbon-route route='{{route}}' pattern="/:page" data="{{data}}" tail="{{tail}}">
+    </carbon-route>
+  </template>
+  <script>
+    Polymer({
+      is: 'redirect-carbon-route',
+      properties: {
+        route: {
+          notify: true
+        },
+        data: {
+          type: Object,
+          notify: true
+        },
+        tail: {
+          notify: true
+        },
+      },
+    });
+  </script>
+</dom-module>

--- a/test/test-app-example-1.html
+++ b/test/test-app-example-1.html
@@ -37,12 +37,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var exampleApp;
 
     setup(function() {
-      originalLocation = window.location.toString();
+      originalLocation = window.location.href;
       exampleApp = fixture('ExampleApp');
     });
 
     teardown(function() {
-      setLocation(originalLocation);
+      window.history.replaceState({}, '', originalLocation);
     });
 
     test('runs through basic usage', function() {
@@ -64,22 +64,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         path: null,
         __queryParams: {}
       });
+      expect(window.location.pathname).to.be.equal('/lol');
 
       // Navigate to /user
       setLocation('/user');
       expect(exampleApp.data).to.be.deep.eq({
         page: 'user'
       });
+
+      // We should have redirected to /user/view because of a redirect in
+      // the example app code.
       expect(exampleApp.route).to.be.deep.eq({
         prefix: '',
-        path: '/user',
+        path: '/user/view',
         __queryParams: {}
       });
       expect(exampleApp.userRoute).to.be.deep.eq({
         prefix: '/user',
-        path: '',
+        path: '/view',
         __queryParams: {}
       });
+      expect(window.location.pathname).to.be.equal('/user/view');
 
       // Navigate to /user/details
       setLocation('/user/details');
@@ -99,6 +104,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         path: '/details',
         __queryParams: {}
       });
+      expect(window.location.pathname).to.be.equal('/user/details');
+
+      exampleApp.set('data.page', 'redirectToUser');
+      expect(window.location.pathname).to.be.equal('/user/view');
+
+      // This triggers two redirects in a row!
+      setLocation('/redirectToUser');
+      expect(window.location.pathname).to.be.equal('/user/view');
 
       // Data binding changes to a different user subpage.
       exampleApp.set('userData.page', 'profile');


### PR DESCRIPTION
Redirection is through the data binding system and no longer needs to be
asynchronous.

This is accomplished by making changes to `tail` and `data` appear atomic
from a notification perspective, as well as some tweaks to our observers to
ensure that they're properly reentrant.

Fixes #44