### PR TITLE
Extract carbon-route-converter into a behavior

### DIFF
--- a/carbon-location.html
+++ b/carbon-location.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-location/iron-location.html">
 <link rel="import" href="../iron-location/iron-query-params.html">
-<link rel="import" href="carbon-route-converter.html">
+<link rel="import" href="carbon-route-converter-behavior.html">
 
 <!--
 `carbon-location` is an element that provides synchronization between the
@@ -48,7 +48,6 @@ Example:
 @element carbon-location
 @demo demo/index.html
 -->
-
 <dom-module id="carbon-location">
   <template>
     <iron-location
@@ -59,14 +58,8 @@ Example:
     </iron-location>
     <iron-query-params
         params-string="{{__query}}"
-        params-object="{{__queryParams}}">
+        params-object="{{queryParams}}">
     </iron-query-params>
-    <carbon-route-converter
-        on-path-changed="__onPathChanged"
-        path="[[__computeRoutePath(__path, __hash, useHashAsPath)]]"
-        query-params="{{__queryParams}}"
-        route="{{route}}">
-    </carbon-route-converter>
   </template>
   <script>
     'use strict';
@@ -145,23 +138,37 @@ Example:
          */
         __hash: {
           type: String
+        },
+
+        /**
+         * The route path, which will be either the hash or the path, depending
+         * on useHashAsPath.
+         */
+        path: {
+          type: String,
+          observer: '__onPathChanged'
         }
       },
 
+      behaviors: [Polymer.CarbonRouteConverterBehavior],
+
+      observers: [
+        '__computeRoutePath(useHashAsPath, __hash, __path)'
+      ],
+
       __computeRoutePath: function() {
-        return this.useHashAsPath ? this.__hash : this.__path;
+        this.path = this.useHashAsPath ? this.__hash : this.__path;
       },
 
-      __onPathChanged: function(event) {
+      __onPathChanged: function() {
         if (!this._readied) {
           return;
         }
-        var path = event.detail.value;
 
         if (this.useHashAsPath) {
-          this.__hash = path;
+          this.__hash = this.path;
         } else {
-          this.__path = path;
+          this.__path = this.path;
         }
       }
     });

--- a/carbon-route-converter-behavior.html
+++ b/carbon-route-converter-behavior.html
@@ -2,6 +2,11 @@
   'use strict';
 
   /**
+   * Provides bidirectional mapping between `path` and `queryParams` and a
+   * carbon-route compatible `route` object.
+   *
+   * For more information, see the docs for `carbon-route-converter`.
+   *
    * @polymerBehavior
    */
   Polymer.CarbonRouteConverterBehavior = {

--- a/carbon-route-converter-behavior.html
+++ b/carbon-route-converter-behavior.html
@@ -1,6 +1,9 @@
 <script>
   'use strict';
 
+  /**
+   * @polymerBehavior
+   */
   Polymer.CarbonRouteConverterBehavior = {
     properties: {
       /**

--- a/carbon-route-converter-behavior.html
+++ b/carbon-route-converter-behavior.html
@@ -1,0 +1,93 @@
+<script>
+  'use strict';
+
+  Polymer.CarbonRouteConverterBehavior = {
+    properties: {
+      /**
+       * A model representing the deserialized path through the route tree, as
+       * well as the current queryParams.
+       *
+       * A route object is the kernel of the routing system. It is intended to
+       * be fed into consuming elements such as `carbon-route`.
+       *
+       * @type {?Object}
+       */
+      route: {
+        type: Object,
+        notify: true
+      },
+
+      /**
+       * A set of key/value pairs that are universally accessible to branches of
+       * the route tree.
+       *
+       * @type {?Object}
+       */
+      queryParams: {
+        type: Object,
+        notify: true
+      },
+
+      /**
+       * The serialized path through the route tree. This corresponds to the
+       * `window.location.pathname` value, and will update to reflect changes
+       * to that value.
+       */
+      path: {
+        type: String,
+        notify: true,
+      }
+    },
+
+    observers: [
+      '_locationChanged(path, queryParams)',
+      '_routeChanged(route.prefix, route.path)',
+      '_routeQueryParamsChanged(route.__queryParams)'
+    ],
+
+    created: function() {
+      this.linkPaths('route.__queryParams', 'queryParams');
+      this.linkPaths('queryParams', 'route.__queryParams');
+    },
+
+    /**
+     * Handler called when the path or queryParams change.
+     */
+    _locationChanged: function() {
+      if (this.route &&
+          this.route.path === this.path &&
+          this.queryParams === this.route.__queryParams) {
+        return;
+      }
+      this.route = {
+        prefix: '',
+        path: this.path,
+        __queryParams: this.queryParams
+      };
+    },
+
+    /**
+     * Handler called when the route prefix and route path change.
+     */
+    _routeChanged: function() {
+      if (!this.route) {
+        return;
+      }
+
+      this.path = this.route.prefix + this.route.path;
+    },
+
+    /**
+     * Handler called when the route queryParams change.
+     *
+     * @param  {Object} queryParams A set of key/value pairs that are
+     * universally accessible to branches of the route tree.
+     */
+    _routeQueryParamsChanged: function(queryParams) {
+      if (!this.route) {
+        return;
+      }
+      this.queryParams = queryParams;
+    }
+  };
+</script>

--- a/carbon-route-converter.html
+++ b/carbon-route-converter.html
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="./carbon-route-converter-behavior.html">
 
 <!--
 `carbon-route-converter` provides a means to convert a path and query
@@ -71,92 +72,6 @@ turn is consumed by the `carbon-route`.
   Polymer({
     is: 'carbon-route-converter',
 
-    properties: {
-      /**
-       * A model representing the deserialized path through the route tree, as
-       * well as the current queryParams.
-       *
-       * A route object is the kernel of the routing system. It is intended to
-       * be fed into consuming elements such as `carbon-route`.
-       *
-       * @type {?Object}
-       */
-      route: {
-        type: Object,
-        notify: true
-      },
-
-      /**
-       * A set of key/value pairs that are universally accessible to branches of
-       * the route tree.
-       *
-       * @type {?Object}
-       */
-      queryParams: {
-        type: Object,
-        notify: true
-      },
-
-      /**
-       * The serialized path through the route tree. This corresponds to the
-       * `window.location.pathname` value, and will update to reflect changes
-       * to that value.
-       */
-      path: {
-        type: String,
-        notify: true,
-      }
-    },
-
-    observers: [
-      '_locationChanged(path, queryParams)',
-      '_routeChanged(route.prefix, route.path)',
-      '_routeQueryParamsChanged(route.__queryParams)'
-    ],
-
-    created: function() {
-      this.linkPaths('route.__queryParams', 'queryParams');
-      this.linkPaths('queryParams', 'route.__queryParams');
-    },
-
-    /**
-     * Handler called when the path or queryParams change.
-     */
-    _locationChanged: function() {
-      if (this.route &&
-          this.route.path === this.path &&
-          this.queryParams === this.route.__queryParams) {
-        return;
-      }
-      this.route = {
-        prefix: '',
-        path: this.path,
-        __queryParams: this.queryParams
-      };
-    },
-
-    /**
-     * Handler called when the route prefix and route path change.
-     */
-    _routeChanged: function() {
-      if (!this.route) {
-        return;
-      }
-
-      this.path = this.route.prefix + this.route.path;
-    },
-
-    /**
-     * Handler called when the route queryParams change.
-     *
-     * @param  {Object} queryParams A set of key/value pairs that are
-     * universally accessible to branches of the route tree.
-     */
-    _routeQueryParamsChanged: function(queryParams) {
-      if (!this.route) {
-        return;
-      }
-      this.queryParams = queryParams;
-    }
+    behaviors: [Polymer.CarbonRouteConverterBehavior]
   });
 </script>


### PR DESCRIPTION
Use this behavior in carbon-location.

Gives a nice performance improvement. This is good for PWAs, as carbon-location is often going to be part of the initial bootup sequence. 